### PR TITLE
Backpatch dio 3 to allow http_parser 4

### DIFF
--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>2.4.0 <3.0.0'
 
 dependencies:
-  http_parser: ">=0.0.1 <4.0.0"
+  http_parser: ">=0.0.1 <5.0.0"
   path: ^1.6.4
 
 dev_dependencies:

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dio
 description: A powerful Http client for Dart, which supports Interceptors, FormData, Request Cancellation, File Downloading, Timeout etc.
-version: 3.0.10
+version: 3.0.11
 homepage: https://github.com/flutterchina/dio
 
 environment:


### PR DESCRIPTION
### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [ ] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [ ] I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...

### Pull Request Description

In order to ease upgrading dependencies, it would be helpful if there were a 3.0.11 release with a wider http_parser range to allow version 4.

I created a 3x branch off of the latest 3 release 3.0.10 and raised the max version for http_parser to allow version 4.
...

